### PR TITLE
fix: must wrap `npm` & `github` publish plugins individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In `package.json`:
   "release": {
     "analyzeCommits": "semantic-release-monorepo",
     "generateNotes": "semantic-release-monorepo",
-    "publish": "semantic-release-monorepo"
+    "publish": ["semantic-release-monorepo/npm", "semantic-release-monorepo/github"]
   }
 }
 ```

--- a/github.js
+++ b/github.js
@@ -1,0 +1,4 @@
+const publish = require('@semantic-release/github');
+const withGitTag = require('./src/with-git-tag');
+
+module.exports = withGitTag(publish);

--- a/index.js
+++ b/index.js
@@ -2,29 +2,16 @@ const { compose } = require('ramda');
 
 const commitAnalyzer = require('@semantic-release/commit-analyzer');
 const releaseNotesGenerator = require('@semantic-release/release-notes-generator');
-const { publish: publishGithub } = require('@semantic-release/github');
-const { publish: publishNpm } = require('@semantic-release/npm');
 
-const pipeline = require('semantic-release/lib/plugins/pipeline');
-const gitTag = require('./src/git-tag');
-
-const overrideOption = (key, wrapperFn) => pluginFn => async (pluginConfig, options) => {
-  const overriddenValue = await wrapperFn(options[key]);
-  return pluginFn(pluginConfig, { ...options, [key]: overriddenValue });
-};
-
-const withPackageCommits = overrideOption('commits', require('./src/with-package-commits'));
-
-const withVersion = overrideOption('nextRelease', async nextRelease =>
-  ({ ...nextRelease, version: await gitTag(nextRelease.version) })
-);
-
-const withGitTag = overrideOption('nextRelease', async nextRelease =>
-  ({ ...nextRelease, gitTag: await gitTag(nextRelease.version) })
-);
+const withPackageCommits = require('./src/with-package-commits');
+const withVersion = require('./src/with-version');
+const withGitTag = require('./src/with-git-tag');
 
 module.exports = {
   analyzeCommits: withPackageCommits(commitAnalyzer),
-  generateNotes: compose(withGitTag, withVersion, withPackageCommits)(releaseNotesGenerator),
-  publish: pipeline([withGitTag(publishNpm), withGitTag(publishGithub)]),
+  generateNotes: compose(
+    withGitTag,
+    withVersion,
+    withPackageCommits
+  )(releaseNotesGenerator),
 };

--- a/npm.js
+++ b/npm.js
@@ -1,0 +1,4 @@
+const publish = require('@semantic-release/npm');
+const withGitTag = require('./src/with-git-tag');
+
+module.exports = withGitTag(publish);

--- a/src/override-option.js
+++ b/src/override-option.js
@@ -1,0 +1,6 @@
+const overrideOption = (key, wrapperFn) => pluginFn => async (pluginConfig, options) => {
+  const overriddenValue = await wrapperFn(options[key]);
+  return pluginFn(pluginConfig, { ...options, [key]: overriddenValue });
+};
+
+module.exports = overrideOption;

--- a/src/with-git-tag.js
+++ b/src/with-git-tag.js
@@ -1,0 +1,9 @@
+const gitTag = require('./git-tag');
+const overrideOption = require('./override-option');
+
+const withGitTag = async nextRelease => ({
+  ...nextRelease,
+  gitTag: await gitTag(nextRelease.version)
+});
+
+module.exports = overrideOption('nextRelease', withGitTag);

--- a/src/with-package-commits.js
+++ b/src/with-package-commits.js
@@ -1,5 +1,6 @@
 const pkgUp = require('pkg-up');
 const { getCommitFiles, getGitRoot } = require('./git-utils');
+const overrideOption = require('./override-option');
 
 const getPackagePath = async () => {
   const path = await pkgUp();
@@ -23,4 +24,4 @@ const withPackageCommits = async commits => {
   );
 };
 
-module.exports = withPackageCommits;
+module.exports = overrideOption('commits', withPackageCommits);

--- a/src/with-version.js
+++ b/src/with-version.js
@@ -1,0 +1,9 @@
+const gitTag = require('./git-tag');
+const overrideOption = require('./override-option');
+
+const withVersion = async nextRelease => ({
+  ...nextRelease,
+  version: await gitTag(nextRelease.version)
+});
+
+module.exports = overrideOption('nextRelease', withVersion);


### PR DESCRIPTION
Incorrectly assumed it was possible to pass an array of plugins from a plugin. User must explicitly pass wrapped `npm` and `github` publish plugins. This is clunky and annoying. Will have to think about how the `semantic-release` plugin system could be improved to allow for composition like we’re trying to achieve here.