### PR TITLE
fix: write `getLastRelease` plugin to work around missing `gitHead`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ In `package.json`:
   "release": {
     "analyzeCommits": "semantic-release-monorepo",
     "generateNotes": "semantic-release-monorepo",
+    "getLastRelease": "semantic-release-monorepo",
     "publish": ["semantic-release-monorepo/npm", "semantic-release-monorepo/github"]
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const { compose } = require('ramda');
 const commitAnalyzer = require('@semantic-release/commit-analyzer');
 const releaseNotesGenerator = require('@semantic-release/release-notes-generator');
 
+const getLastRelease = require('./src/get-last-release');
 const withPackageCommits = require('./src/with-package-commits');
 const withVersion = require('./src/with-version');
 const withGitTag = require('./src/with-git-tag');
@@ -14,4 +15,5 @@ module.exports = {
     withVersion,
     withPackageCommits
   )(releaseNotesGenerator),
+  getLastRelease,
 };

--- a/src/get-last-release.js
+++ b/src/get-last-release.js
@@ -1,0 +1,26 @@
+const { getLastRelease } = require('@semantic-release/npm');
+const getVersionHead = require('semantic-release/lib/get-version-head');
+const gitTag = require('./git-tag');
+
+module.exports = async (pluginConfig, options) => {
+  const result = await getLastRelease(pluginConfig, options);
+
+  /**
+   * Multiple problems identifying the last release for a monorepo package:
+   *
+   * 1. `npm` doesn't publish `gitHead` as part of a release unless `package.json` and `.git`
+   *    are in the same folder (never true for a monorepo).
+   *    https://github.com/npm/read-package-json/issues/66#issuecomment-222036879
+   *
+   * 2. We can use `semantic-release`'s fallback strategy, searching for a matching git tag,
+   *    but we must update the git tag format to be compatible with the monorepo workflow.
+   **/
+  if (!result.gitHead) {
+    return {
+      ...result,
+      ...await getVersionHead(null, await gitTag(result.version))
+    };
+  }
+
+  return result;
+};


### PR DESCRIPTION
Multiple problems identifying the last release for a monorepo package:

1. `npm` doesn't publish `gitHead` as part of a release unless `package.json` and `.git` are in the same folder (never true for a monorepo).

    https://github.com/npm/read-package-json/issues/66#issuecomment-222036879

2. We can use `semantic-release`'s fallback strategy, searching for a matching git tag, but we must update the git tag format to be compatible with the monorepo workflow.