### PR TITLE
feat: integrate @semantic-release/git

### DIFF
--- a/git.js
+++ b/git.js
@@ -1,0 +1,12 @@
+const { publish } = require('@semantic-release/git');
+const versionToGitTag = require('./src/version-to-git-tag');
+
+const {
+  mapNextReleaseVersionToNextReleaseGitTag,
+} = require('./src/options-transforms');
+
+module.exports = async (pluginConf, options) =>
+  publish(
+    pluginConf,
+    await mapNextReleaseVersionToNextReleaseGitTag(versionToGitTag)(options)
+  );


### PR DESCRIPTION
This PR integrates [semantic-release/git](https://github.com/semantic-release/git) in order to allow commiting files to git on release.
It's pretty much a copy of the `github.js` file, only substituting github with git.
