### PR TITLE
fix: lock `semantic-release` to `11.1.0` since `11.2.0` breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "^11.1.0"
+    "semantic-release": "~11.1.0"
   },
   "dependencies": {
     "debug": "^3.1.0",
@@ -26,7 +26,7 @@
     "jest": "^21.2.1",
     "lint-staged": "^6.0.0",
     "prettier": "^1.9.2",
-    "semantic-release": "^11.1.0",
+    "semantic-release": "~11.1.0",
     "semantic-release-github-pr": "^2.0.0"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,7 +3158,7 @@ semantic-release-plugin-decorators@^1.2.0:
     import-from "^2.1.0"
     lodash "^4.17.4"
 
-semantic-release@^11.1.0:
+semantic-release@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/semantic-release/-/semantic-release-11.1.0.tgz#db0316065d7612d1db5a2e26aaa0c3f7edebb6c3"
   dependencies:


### PR DESCRIPTION
We've needed to make use an internal file, `/lib/get-version-head`, that was removed in `semantic-release` `11.2.0`.