### PR TITLE
fix(withVersionHead): force the `gitHead` fallback algorithm

### DIFF
--- a/src/with-version-head.js
+++ b/src/with-version-head.js
@@ -14,12 +14,12 @@ const gitTag = require('./version-to-git-tag');
 const withVersionHead = plugin => async (pluginConfig, options) => {
   const release = await plugin(pluginConfig, options);
 
-  if (release && !release.gitHead) {
-    return {
-      ...release,
-      ...(await getVersionHead(null, await gitTag(release.version))),
-    };
-  }
+  // TODO: Don't trust result of `plugin` for now since its likely
+  // `@semantic-release/npm` returning the wrong information.
+  return {
+    ...release,
+    ...(await getVersionHead(null, await gitTag(release.version))),
+  };
 };
 
 module.exports = withVersionHead;


### PR DESCRIPTION
When the wrapped `plugin` is `@semantic-release/npm`, it will as of `2.5.0` try to find a fallback `gitHead` itself. If it's found, `gitHead` will be populated but incorrect for our purposes, yet our fallback algorithm won't be used.

For now (at least while we remain locked to `semantic-release` `~11.1.0`), force the fallback algorithm.