### PR TITLE
fix(withVersionHead): apply fallback iff plugin finds previous release

### DIFF
--- a/src/with-version-head.js
+++ b/src/with-version-head.js
@@ -14,12 +14,12 @@ const gitTag = require('./version-to-git-tag');
 const withVersionHead = plugin => async (pluginConfig, options) => {
   const release = await plugin(pluginConfig, options);
 
-  // TODO: Don't trust result of `plugin` for now since its likely
-  // `@semantic-release/npm` returning the wrong information.
-  return {
-    ...release,
-    ...(await getVersionHead(null, await gitTag(release.version))),
-  };
+  if (release) {
+    return {
+      ...release,
+      ...(await getVersionHead(null, await gitTag(release.version))),
+    };
+  }
 };
 
 module.exports = withVersionHead;


### PR DESCRIPTION
If the package is new, `release` will be empty.