### PR TITLE
Last run file

### DIFF
--- a/src/git-utils.js
+++ b/src/git-utils.js
@@ -1,11 +1,13 @@
-const { pipeP, split } = require('ramda');
+const { pipe, pipeP, split, prop, not } = require('ramda');
 const execa = require('execa');
 const debug = require('debug')('semantic-release:monorepo');
 
-const git = async (args, options = {}) => {
-  const { stdout } = await execa('git', args, options);
-  return stdout;
-};
+const stdout = prop('stdout');
+const bool = pipe(prop('code'), Boolean, not);
+
+const git = async (args, options = {}) => await execa('git', args, options);
+
+const getHead = pipeP(() => git(['rev-parse', 'HEAD']), stdout);
 
 /**
  * // https://stackoverflow.com/questions/424071/how-to-list-all-the-files-in-a-commit
@@ -15,6 +17,7 @@ const git = async (args, options = {}) => {
  */
 const getCommitFiles = pipeP(
   hash => git(['diff-tree', '--no-commit-id', '--name-only', '-r', hash]),
+  stdout,
   split('\n')
 );
 
@@ -23,7 +26,7 @@ const getCommitFiles = pipeP(
  * @async
  * @return {Promise<String>} System path of the git repository.
  */
-const getRoot = () => git(['rev-parse', '--show-toplevel']);
+const getRoot = pipeP(() => git(['rev-parse', '--show-toplevel']), stdout);
 
 /**
  * Get the commit sha for a given tag.
@@ -32,25 +35,40 @@ const getRoot = () => git(['rev-parse', '--show-toplevel']);
  * @param {string} tagName Tag name for which to retrieve the commit sha.
  * @return {string} The commit sha of the tag in parameter or `null`.
  */
-const getTagHead = tagName =>
-  git(['rev-list', '-1', tagName], { reject: false });
+const getTagHead = pipeP(
+  tagName => git(['rev-list', '-1', tagName], { reject: false }),
+  stdout
+);
 
 /**
  * Fetch tags from the repository's origin.
  */
-const fetchTags = () => git(['fetch', '--tags']);
+const fetchTags = pipeP(() => git(['fetch', '--tags']), stdout);
 
 /**
  * Unshallow the git repository (retrieving every commit and tags).
  * Adapted from: https://github.com/semantic-release/npm/blob/cf039fdafda1a5ce43c2a5f033160cd46487f102/lib/git.js
  */
-const unshallow = () =>
-  git(['fetch', '--unshallow', '--tags'], { reject: false });
+const unshallow = pipeP(
+  () => git(['fetch', '--unshallow', '--tags'], { reject: false }),
+  stdout
+);
+
+// https://stackoverflow.com/a/13526591/89594
+const isAncestor = pipeP(
+  (ancestor, descendant) =>
+    git(['merge-base', '--is-ancestor', ancestor, descendant], {
+      reject: false,
+    }),
+  bool
+);
 
 module.exports = {
   getCommitFiles,
+  getHead,
   getRoot,
   getTagHead,
   fetchTags,
+  isAncestor,
   unshallow,
 };

--- a/src/last-run-file.js
+++ b/src/last-run-file.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const { resolve } = require('path');
+const { promisify } = require('util');
+const readPkg = require('read-pkg');
+const { getHead } = require('./git-utils');
+const debug = require('debug')('semantic-release:monorepo');
+
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+const FILE_PATH = resolve(process.env.HOME, '.semantic-release-monorepo');
+
+const readLastRunHead = async () => {
+  try {
+    debug('Trying to read last-run HEAD from %s', FILE_PATH);
+    const packages = await readLastRunFile();
+    const { name } = await readPkg();
+    const hash = packages[name];
+
+    if (hash) {
+      debug('Last ran against package %s at %s', name, hash);
+    } else {
+      debug('No "last-run" found for package %s', name);
+    }
+
+    return hash;
+  } catch (error) {
+    debug(error);
+    return undefined;
+  }
+};
+
+const writeLastRunHead = async () => {
+  try {
+    debug('Trying to write HEAD to last-run to %s', FILE_PATH);
+    const packages = await readLastRunFile();
+    const { name } = await readPkg();
+    packages[name] = await getHead();
+    await writeFile(FILE_PATH, JSON.stringify(packages));
+  } catch (error) {
+    debug(error);
+  }
+};
+
+const readLastRunFile = async () => {
+  try {
+    return JSON.parse(await readFile(FILE_PATH));
+  } catch (err) {
+    return {};
+  }
+};
+
+module.exports = {
+  readLastRunHead,
+  writeLastRunHead,
+};


### PR DESCRIPTION
Over time, `semantic-release-monorepo`’s performance may degrade if there are a lot of stale packages; packages where there’s a large range of commits to be parsed between the last release of the given package and the repo’s git head.

Using a “last-run” file, we can track which commits have already been parsed for each package, allowing us to start further ahead in the repo’s commit history than when using the commit from the package’s last release.

TODO: Write docs and clean up.