### PR TITLE
fix: lock down `semantic-release` peer dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "^13.1.0"
+    "semantic-release": "13.1.0 - 13.2.0"
   },
   "dependencies": {
     "debug": "^3.1.0",


### PR DESCRIPTION
Due to reliance on `semantic-release` internals, its version 13.3.0 breaks our current implementation.