### PR TITLE
fix: limited maximum concurrent process spawns

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "execa": "^0.8.0",
+    "p-limit": "^1.2.0",
     "pkg-up": "^2.0.0",
     "ramda": "^0.25.0",
     "read-pkg": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,6 +2990,12 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"


### PR DESCRIPTION
Limited the concurrent processes spawned with memoizedGetCommitFiles since large releases (>1400
commits) will hit the concurrent process limit and throw an EAGAIN exception.
The default concurrency is now 500 threads, this can be overwritten by setting the environment variable SRM_THREADS.

fixes #43