### PR TITLE
feat(git): get files include merge commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "semantic-release-monorepo",
+  "name": "@dotfold/semantic-release-monorepo",
   "version": "0.0.0-development",
   "description": "Plugins for `semantic-release` allowing it to be used with a monorepo.",
   "main": "src/index.js",

--- a/src/git-utils.js
+++ b/src/git-utils.js
@@ -13,7 +13,7 @@ const git = async (args, options = {}) => {
  * @return {Promise<Array>} List of modified files in a commit.
  */
 const getCommitFiles = pipeP(
-  hash => git(['diff-tree', '--no-commit-id', '--name-only', '-r', hash]),
+  hash => git(['diff-tree', '--no-commit-id', '--name-only', '-r', '-m' hash]),
   split('\n')
 );
 
@@ -28,3 +28,10 @@ module.exports = {
   getCommitFiles,
   getRoot,
 };
+
+
+// merge commit 
+git diff-tree --no-commit-id --name-only -r 059cc69a7aaf40d85432afc7fab2620f267700c6
+
+// actual commit
+git diff-tree --no-commit-id --name-only -r 4635eec8800660d3a421ba55156d360a0380674b


### PR DESCRIPTION
By default the `diff-tree` command does not include merge commits. Merge commits contain important information such as issue and PR references that are used in generating release notes.

Note that the merge commit itself won't appear in release notes, because it doesn't match any style in analyze commits.