### PR TITLE
fix: update `semantic-release` peer dep to support 15.x.x 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "13.4.1 - 15.6.x"
+    "semantic-release": "13.4.1 - 15.x.x"
   },
   "dependencies": {
     "debug": "^3.1.0",


### PR DESCRIPTION
As of `6.1.0`, this library should again be fully compatible with the latest `semantic-release` major version (15.x.x).

This reverts commit 6a4c9b8a2f7e84bb9b48e250c633203708d5608e.